### PR TITLE
fix: Darken AI response text for readability

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,7 @@ input, textarea {
 
 /* Prose styles for AI responses */
 .prose {
-  color: theme('colors.text-secondary');
+  color: theme('colors.text-primary');
 }
 
 .prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6 {


### PR DESCRIPTION
I changed the color of the AI response text from 'text-secondary' to 'text-primary' to provide better contrast and improve readability, following your feedback.