### PR TITLE
feat: Add premium button and usage display to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,10 +5,11 @@ import { useAuth } from '../contexts/AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { AuthModal } from './AuthModal';
 import { UsageTracker } from '../utils/usageTracker';
+import HeaderPremium from './HeaderPremium';
 
-type HeaderProps = { onPremiumClick: () => void };
+type HeaderProps = Record<string, never>;
 
-export const Header: React.FC<HeaderProps> = ({ onPremiumClick }) => {
+export const Header: React.FC<HeaderProps> = () => {
   const { user, signOut } = useAuth();
   const { language, setLanguage, t } = useLanguage();
   const [showAuthModal, setShowAuthModal] = React.useState(false);
@@ -161,11 +162,7 @@ export const Header: React.FC<HeaderProps> = ({ onPremiumClick }) => {
           <a href="#articles" className="text-base text-text-secondary hover:text-text-primary transition-colors duration-300 ease-in-out">
             {t('nav.articles')}
           </a>
-          {user && (
-            <button onClick={onPremiumClick} className="text-base text-accent hover:text-primary transition-colors duration-300 ease-in-out">
-              Премиум
-            </button>
-          )}
+          <HeaderPremium />
           <button 
             onClick={handleAuthAction}
             className="px-4 lg:px-6 py-2 text-white rounded-full transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg shadow-primary/30 text-sm lg:text-base flex items-center space-x-2 bg-gradient-to-r from-primary to-accent hover:shadow-xl hover:shadow-primary/50"
@@ -265,17 +262,9 @@ export const Header: React.FC<HeaderProps> = ({ onPremiumClick }) => {
                 >
                   {t('nav.articles')}
                 </a>
-                {user && (
-                  <button
-                    onClick={() => {
-                      onPremiumClick();
-                      setIsMobileMenuOpen(false);
-                    }}
-                    className="block w-full text-left text-text-secondary hover:text-primary transition-colors duration-300 ease-in-out py-2"
-                  >
-                    Премиум
-                  </button>
-                )}
+                <div className="py-2">
+                  <HeaderPremium />
+                </div>
                 <button 
                   onClick={() => {
                     handleAuthAction();

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -1,0 +1,34 @@
+import PricingModal from '../components/PricingModal';
+import { useState, useEffect } from 'react';
+import { supabase } from '../supabaseClient';
+
+function HeaderPremium() {
+  const [open, setOpen] = useState(false);
+  const [remaining, setRemaining] = useState<number | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) { setRemaining(null); return; }
+      const { data } = await supabase
+        .from('profiles')
+        .select('daily_limit,used_today')
+        .eq('user_id', user.id)
+        .single();
+      if (data) setRemaining(Math.max(0, data.daily_limit - data.used_today));
+    })();
+  }, []);
+
+  return (
+    <>
+      {remaining !== null && (
+        <span className="mr-3 text-sm text-gray-600">Осталось сегодня: <b>{remaining}</b></span>
+      )}
+      <button onClick={() => setOpen(true)} className="rounded-xl bg-pink-500 px-4 py-2 text-white">
+        Премиум
+      </button>
+      <PricingModal open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+}
+export default HeaderPremium;


### PR DESCRIPTION
This commit introduces a new `HeaderPremium` component and integrates it into the main `Header`.

The `HeaderPremium` component:
- Displays your remaining daily requests.
- Provides a "Premium" button that opens the `PricingModal`.

The main `Header` component has been refactored to:
- Remove the `onPremiumClick` prop.
- Use the new `HeaderPremium` component in both desktop and mobile views.