### PR TITLE
feat: Redesign premium button and remove usage text

### DIFF
--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -1,30 +1,15 @@
 import PricingModal from '../components/PricingModal';
-import { useState, useEffect } from 'react';
-import { supabase } from '../supabaseClient';
+import { useState } from 'react';
 
 function HeaderPremium() {
   const [open, setOpen] = useState(false);
-  const [remaining, setRemaining] = useState<number | null>(null);
-
-  useEffect(() => {
-    (async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) { setRemaining(null); return; }
-      const { data } = await supabase
-        .from('profiles')
-        .select('daily_limit,used_today')
-        .eq('user_id', user.id)
-        .single();
-      if (data) setRemaining(Math.max(0, data.daily_limit - data.used_today));
-    })();
-  }, []);
 
   return (
     <>
-      {remaining !== null && (
-        <span className="mr-3 text-sm text-gray-600">Осталось сегодня: <b>{remaining}</b></span>
-      )}
-      <button onClick={() => setOpen(true)} className="rounded-xl bg-pink-500 px-4 py-2 text-white">
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 text-white rounded-full transition-all duration-300 ease-in-out transform hover:scale-105 shadow-lg shadow-primary/30 bg-gradient-to-r from-primary to-accent hover:shadow-xl hover:shadow-primary/50 text-sm font-medium"
+      >
         Премиум
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />


### PR DESCRIPTION
This commit refines the `HeaderPremium` component by:
1.  Removing the "Remaining today" text display. The associated state and effect for fetching this data have also been removed to simplify the component.
2.  Redesigning the "Premium" button to align with the application's overall visual style. It now uses a gradient background, a fully rounded shape, and hover effects consistent with other primary buttons.