### PR TITLE
feat: Update premium text with new gradient

### DIFF
--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -11,7 +11,7 @@ function HeaderPremium() {
         className="group flex items-center space-x-2 transition-opacity duration-300 hover:opacity-80"
       >
         <img src="https://blog.lunarum.app/wp-content/uploads/2025/08/vip-c.png" alt="" className="w-5 h-5 transition-transform duration-300 group-hover:scale-110" />
-        <span className="font-semibold text-transparent bg-clip-text bg-gradient-to-r from-purple-600 via-pink-600 to-red-500 animate-gradient-x">
+        <span className="font-semibold text-transparent bg-clip-text bg-gradient-to-r from-orange-500 to-teal-400 animate-gradient-x">
           Премиум
         </span>
       </button>


### PR DESCRIPTION
This commit updates the 'Premium' text in the header with a new, more vibrant gradient as you requested.

The new gradient uses an orange-to-sea-wave color scheme (`from-orange-500 to-teal-400`) to make the text stand out more against the application's background. The shimmering animation is kept to maintain the dynamic feel.