### PR TITLE
feat: Refactor Account button into a dedicated component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,9 +4,9 @@ import { Sparkles, Menu, X, Globe, Music, HelpCircle } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { AuthModal } from './AuthModal';
-import AccountModal from './AccountModal';
 import { UsageTracker } from '../utils/usageTracker';
 import HeaderPremium from './HeaderPremium';
+import HeaderAccountButton from './HeaderAccountButton';
 
 type HeaderProps = Record<string, never>;
 
@@ -14,7 +14,6 @@ export const Header: React.FC<HeaderProps> = () => {
   const { user, signOut } = useAuth();
   const { language, setLanguage, t } = useLanguage();
   const [showAuthModal, setShowAuthModal] = React.useState(false);
-  const [showAccountModal, setShowAccountModal] = React.useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = React.useState(false);
   const [isAtmosphereMode, setIsAtmosphereMode] = React.useState<boolean>(false);
   const [showAtmosphereTooltip, setShowAtmosphereTooltip] = React.useState<boolean>(false);
@@ -164,11 +163,7 @@ export const Header: React.FC<HeaderProps> = () => {
           <a href="#articles" className="text-base text-text-secondary hover:text-text-primary transition-colors duration-300 ease-in-out">
             {t('nav.articles')}
           </a>
-          {user && (
-            <button onClick={() => setShowAccountModal(true)} className="text-base text-text-secondary hover:text-text-primary transition-colors duration-300 ease-in-out">
-              Аккаунт
-            </button>
-          )}
+          {user && <HeaderAccountButton onOpenAuth={() => setShowAuthModal(true)} />}
           <HeaderPremium />
           <button
             onClick={handleAuthAction}
@@ -270,15 +265,12 @@ export const Header: React.FC<HeaderProps> = () => {
                   {t('nav.articles')}
                 </a>
                 {user && (
-                  <button
-                    onClick={() => {
-                      setShowAccountModal(true);
+                  <div className="py-2">
+                    <HeaderAccountButton onOpenAuth={() => {
                       setIsMobileMenuOpen(false);
-                    }}
-                    className="block w-full text-left text-text-secondary hover:text-primary transition-colors duration-300 ease-in-out py-2"
-                  >
-                    Аккаунт
-                  </button>
+                      setShowAuthModal(true);
+                    }} />
+                  </div>
                 )}
                 <div className="py-2">
                   <HeaderPremium />
@@ -304,7 +296,6 @@ export const Header: React.FC<HeaderProps> = () => {
         onClose={() => setShowAuthModal(false)}
         onSuccess={handleAuthSuccess}
       />
-      <AccountModal open={showAccountModal} onClose={() => setShowAccountModal(false)} onOpenAuth={() => { setShowAccountModal(false); setShowAuthModal(true); }} />
     </>
   );
 };

--- a/src/components/HeaderAccountButton.tsx
+++ b/src/components/HeaderAccountButton.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import AccountModal from './AccountModal';
+import { supabase } from '../supabaseClient';
+
+export default function HeaderAccountButton({ onOpenAuth }: { onOpenAuth?: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [remaining, setRemaining] = useState<number | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) { setRemaining(null); return; }
+      const { data } = await supabase
+        .from('profiles')
+        .select('daily_limit,used_today')
+        .eq('user_id', user.id).single();
+      if (data) setRemaining(Math.max(0, (data.daily_limit ?? 0) - (data.used_today ?? 0)));
+    })();
+  }, []);
+
+  return (
+    <>
+      {remaining !== null && (
+        <span className="mr-3 hidden text-sm text-gray-600 md:inline">
+          Осталось: <b>{remaining}</b>
+        </span>
+      )}
+      <button
+        onClick={() => setOpen(true)}
+        className="rounded-xl bg-pink-500 px-4 py-2 text-white"
+      >
+        Аккаунт
+      </button>
+      <AccountModal open={open} onClose={() => setOpen(false)} onOpenAuth={onOpenAuth} />
+    </>
+  );
+}


### PR DESCRIPTION
This commit refactors the Account button and its associated modal logic out of the main Header component and into a new, self-contained 'HeaderAccountButton.tsx' component.

This change improves component encapsulation and cleans up the Header component. The new `HeaderAccountButton` component is now responsible for:
- Managing the state for the AccountModal.
- Fetching and displaying your remaining daily usage.
- Rendering the 'Account' button and the `AccountModal`.