### PR TITLE
Refactor: Revert branding to Femmify and Feminine AI

### DIFF
--- a/public/offer.html
+++ b/public/offer.html
@@ -1,6 +1,6 @@
 <!doctype html><html lang="ru"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Публичная оферта — Lunarum.app</title>
+<title>Публичная оферта — femmify.me</title>
 <style>
   body{font:16px/1.55 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222;margin:0;background:#fff}
   main{max-width:880px;margin:40px auto;padding:0 16px}
@@ -13,8 +13,8 @@
 <h1>Публичная оферта</h1>
 <p class="muted">Редакция от 13.08.2025</p>
 
-<p>Настоящий документ является предложением (офертой) владельца сервиса <b>Lunarum.app</b>
-(сайт: <a href="https://lunarum.app/">https://lunarum.app/</a>, далее — «Сервис», «Исполнитель»)
+<p>Настоящий документ является предложением (офертой) владельца сервиса <b>femmify</b>
+(сайт: <a href="https://femmify.me/">https://femmify.me/</a>, далее — «Сервис», «Исполнитель»)
 заключить договор возмездного оказания услуг с любым дееспособным лицом
 (далее — «Пользователь») на условиях ниже. Принятие оферты (оплата) означает заключение договора.</p>
 
@@ -35,7 +35,7 @@
 <h2>4. Ограничения и лимиты</h2>
 <ul>
   <li>Оплаченный доступ: до <b>50 запросов</b> к ИИ в сутки на аккаунт.</li>
-  <li>Бесплатный доступ — согласно информации на сайте <a href="https://lunarum.app">lunarum.app</a>.</li>
+  <li>Бесплатный доступ — согласно информации на сайте <a href="https://femmify.me">femmify.me</a>.</li>
   <li>Сервис не предназначен для медицинских, юридических и иных критически важных консультаций.</li>
 </ul>
 
@@ -55,8 +55,8 @@
 Исполнитель вправе ограничить доступ при нарушении правил использования, злоупотреблениях и попытках обхода лимитов.</p>
 
 <h2>9. Контакты</h2>
-<p>E-mail поддержки: <a href="mailto:support@lunarum.app">support@lunarum.app</a><br>
-Сайт: <a href="https://lunarum.app/">https://lunarum.app/</a></p>
+<p>E-mail поддержки: <a href="mailto:support@femmify.me">support@femmify.me</a><br>
+Сайт: <a href="https://femmify.me/">https://femmify.me/</a></p>
 
 <p class="muted">Оплачивая доступ, вы подтверждаете ознакомление и согласие с условиями настоящей оферты.</p>
 </main></body></html>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,6 +1,6 @@
 <!doctype html><html lang="ru"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Политика конфиденциальности — Lunarum.app</title>
+<title>Политика конфиденциальности — femmify.me</title>
 <style>
   body{font:16px/1.55 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222;margin:0;background:#fff}
   main{max-width:880px;margin:40px auto;padding:0 16px}

--- a/public/refund.html
+++ b/public/refund.html
@@ -1,6 +1,6 @@
 <!doctype html><html lang="ru"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Политика оплаты и возврата — Lunarum.app</title>
+<title>Политика оплаты и возврата — femmify.me</title>
 <style>
   body{font:16px/1.55 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#222;margin:0;background:#fff}
   main{max-width:880px;margin:40px auto;padding:0 16px}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -22,10 +22,10 @@
     "trustedUsers": "Trusted by 100K+ Users"
   },
   "footer": {
-    "brandName": "Mystical AI",
+    "brandName": "Feminine AI",
     "createdWith": "Created with",
     "forSeekers": "for wisdom seekers",
-    "copyright": "© 2025 Mystical AI. All rights reserved.",
+    "copyright": "© 2025 Feminine AI. All rights reserved.",
     "privacy": "Privacy Policy",
     "terms": "Terms of Service"
   },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -22,10 +22,10 @@
     "trustedUsers": "Доверяют 100К+ пользователей"
   },
   "footer": {
-    "brandName": "Lunarum.app",
+    "brandName": "femmify.me",
     "createdWith": "Создано с",
     "forSeekers": "для искателей мудрости",
-    "copyright": "© 2025 Lunarum.app. Все права защищены.",
+    "copyright": "© 2025 femmify.me. Все права защищены.",
     "privacy": "Политика конфиденциальности",
     "terms": "Условия использования"
   },


### PR DESCRIPTION
This commit reverts the branding changes based on your feedback.

- The brand name in the Russian localization file (`ru.json`) and all static legal pages (`public/*.html`) has been changed from "Lunarum.app" back to "femmify.me".
- The brand name in the English localization file (`en.json`) has been changed from "Mystical AI" to "Feminine AI" as per your instruction.