### PR TITLE
Style header buttons with gradient text and underline

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,7 +7,6 @@ import { AuthModal } from './AuthModal';
 import AccountModal from './AccountModal';
 import { UsageTracker } from '../utils/usageTracker';
 import HeaderPremium from './HeaderPremium';
-import { supabase } from '../supabaseClient';
 
 type HeaderProps = Record<string, never>;
 
@@ -151,11 +150,17 @@ export const Header: React.FC<HeaderProps> = () => {
         </div>
         
         <nav className="flex items-center space-x-2 sm:space-x-4 xl:space-x-6">
-          <a href="#about" className="hidden lg:block text-base text-text-secondary hover:text-text-primary transition-colors duration-300 ease-in-out">
-            {t('nav.about')}
+          <a href="#about" className="relative group hidden lg:block px-3 py-2">
+            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+              {t('nav.about')}
+            </span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
-          <a href="#articles" className="text-sm sm:text-base font-semibold text-accent-vibrant border-b-2 border-accent-vibrant/50 hover:border-accent-vibrant transition-all duration-300 ease-in-out">
-            {t('nav.articles')}
+          <a href="#articles" className="relative group px-3 py-2">
+            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+              {t('nav.articles')}
+            </span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -8,12 +8,12 @@ function HeaderPremium() {
     <>
       <button
         onClick={() => setOpen(true)}
-        className="group flex items-center space-x-2 transition-opacity duration-300 hover:opacity-80"
+        className="relative group px-3 py-2"
       >
-        <img src="https://blog.femmify.me/wp-content/uploads/2025/08/vip-c.png" alt="" className="w-5 h-5 transition-transform duration-300 group-hover:scale-110" />
-        <span className="font-semibold text-transparent bg-clip-text bg-gradient-to-r from-orange-500 to-teal-400 animate-gradient-x">
+        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
           Премиум
         </span>
+        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />
     </>


### PR DESCRIPTION
This commit updates the styling for the "О нас", "Блог", and "Премиум" navigation links in the header.

- Applies a two-color gradient (`secondary` to `primary`) to the text of the links.
- Adds a gradient underline that appears on hover, creating a smooth and visually appealing effect.
- Ensures a consistent look and feel across the three navigation elements.
- Removes an unused `supabase` import from `Header.tsx` that was caught by the linter.