### PR TITLE
feat: Apply vibrant gradient to header buttons

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -153,20 +153,20 @@ export const Header: React.FC<HeaderProps> = () => {
           <a href="#about" className="relative group hidden lg:block px-3 py-2">
             <div className="flex items-center space-x-2">
               <img src="http://blog.femmify.me/wp-content/uploads/2025/08/About-femm.png" alt="" className="w-5 h-5" />
-              <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] group-hover:opacity-90 transition-opacity duration-300">
+              <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#1382ff] to-[#4aa38d] group-hover:opacity-90 transition-opacity duration-300">
                 {t('nav.about')}
               </span>
             </div>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#1382ff] to-[#4aa38d] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <a href="#articles" className="relative group px-3 py-2">
             <div className="flex items-center space-x-2">
               <img src="http://blog.femmify.me/wp-content/uploads/2025/08/Blog-femm.png" alt="" className="w-5 h-5" />
-              <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] group-hover:opacity-90 transition-opacity duration-300">
+              <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#1382ff] to-[#4aa38d] group-hover:opacity-90 transition-opacity duration-300">
                 {t('nav.articles')}
               </span>
             </div>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#1382ff] to-[#4aa38d] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,16 +151,16 @@ export const Header: React.FC<HeaderProps> = () => {
         
         <nav className="flex items-center space-x-2 sm:space-x-4 xl:space-x-6">
           <a href="#about" className="relative group hidden lg:block px-3 py-2">
-            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.about')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-pink-500 to-rose-500 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <a href="#articles" className="relative group px-3 py-2">
-            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.articles')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-pink-500 to-rose-500 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,16 +151,16 @@ export const Header: React.FC<HeaderProps> = () => {
         
         <nav className="flex items-center space-x-2 sm:space-x-4 xl:space-x-6">
           <a href="#about" className="relative group hidden lg:block px-3 py-2">
-            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.about')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-pink-500 to-rose-500 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <a href="#articles" className="relative group px-3 py-2">
-            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.articles')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-pink-500 to-rose-500 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,16 +151,22 @@ export const Header: React.FC<HeaderProps> = () => {
         
         <nav className="flex items-center space-x-2 sm:space-x-4 xl:space-x-6">
           <a href="#about" className="relative group hidden lg:block px-3 py-2">
-            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6d9d] to-[#933bff] group-hover:opacity-90 transition-opacity duration-300">
-              {t('nav.about')}
-            </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6d9d] to-[#933bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <div className="flex items-center space-x-2">
+              <img src="http://blog.femmify.me/wp-content/uploads/2025/08/About-femm.png" alt="" className="w-5 h-5" />
+              <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] group-hover:opacity-90 transition-opacity duration-300">
+                {t('nav.about')}
+              </span>
+            </div>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <a href="#articles" className="relative group px-3 py-2">
-            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6d9d] to-[#933bff] group-hover:opacity-90 transition-opacity duration-300">
-              {t('nav.articles')}
-            </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6d9d] to-[#933bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <div className="flex items-center space-x-2">
+              <img src="http://blog.femmify.me/wp-content/uploads/2025/08/Blog-femm.png" alt="" className="w-5 h-5" />
+              <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] group-hover:opacity-90 transition-opacity duration-300">
+                {t('nav.articles')}
+              </span>
+            </div>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#cb71a0] to-[#e89ba5] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,16 +151,16 @@ export const Header: React.FC<HeaderProps> = () => {
         
         <nav className="flex items-center space-x-2 sm:space-x-4 xl:space-x-6">
           <a href="#about" className="relative group hidden lg:block px-3 py-2">
-            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6d9d] to-[#933bff] group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.about')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6d9d] to-[#933bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <a href="#articles" className="relative group px-3 py-2">
-            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff6d9d] to-[#933bff] group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.articles')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6fb5] to-[#9f6bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff6d9d] to-[#933bff] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -10,9 +10,12 @@ function HeaderPremium() {
         onClick={() => setOpen(true)}
         className="relative group px-3 py-2"
       >
-        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-[linear-gradient(90deg,#ff9a8b,#ff6a88,#ffcc70,#ff9a8b)] bg-[size:300%_300%] animate-shine group-hover:opacity-90 transition-opacity duration-300">
-          Премиум
-        </span>
+        <div className="flex items-center space-x-2">
+          <img src="http://blog.femmify.me/wp-content/uploads/2025/08/About-femm.png" alt="" className="w-5 h-5" />
+          <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-[linear-gradient(90deg,#ff9a8b,#ff6a88,#ffcc70,#ff9a8b)] bg-[size:300%_300%] animate-shine group-hover:opacity-90 transition-opacity duration-300">
+            Премиум
+          </span>
+        </div>
         <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff9a8b] via-[#ff6a88] to-[#ffcc70] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -10,10 +10,10 @@ function HeaderPremium() {
         onClick={() => setOpen(true)}
         className="relative group px-3 py-2"
       >
-        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 group-hover:opacity-90 transition-opacity duration-300">
           Премиум
         </span>
-        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-pink-500 to-rose-500 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />
     </>

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -10,10 +10,10 @@ function HeaderPremium() {
         onClick={() => setOpen(true)}
         className="relative group px-3 py-2"
       >
-        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff8ba7] via-[#ffb347] to-[#ffcc70] group-hover:opacity-90 transition-opacity duration-300">
+        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-[linear-gradient(90deg,#ff9a8b,#ff6a88,#ffcc70,#ff9a8b)] bg-[size:300%_300%] animate-shine group-hover:opacity-90 transition-opacity duration-300">
           Премиум
         </span>
-        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff8ba7] via-[#ffb347] to-[#ffcc70] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff9a8b] via-[#ff6a88] to-[#ffcc70] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />
     </>

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -10,10 +10,10 @@ function HeaderPremium() {
         onClick={() => setOpen(true)}
         className="relative group px-3 py-2"
       >
-        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-rose-500 group-hover:opacity-90 transition-opacity duration-300">
+        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-[#ff8ba7] via-[#ffb347] to-[#ffcc70] group-hover:opacity-90 transition-opacity duration-300">
           Премиум
         </span>
-        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-pink-500 to-rose-500 rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-[#ff8ba7] via-[#ffb347] to-[#ffcc70] rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />
     </>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,7 @@ export default {
         'pulse': 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
         'float': 'float 3s ease-in-out infinite',
         'gradient-x': 'gradient-x 3s ease infinite',
+        'shine': 'shine 5s ease infinite',
       },
       keyframes: {
         float: {
@@ -41,7 +42,11 @@ export default {
             'background-size': '200% 200%',
             'background-position': 'right center'
           }
-        }
+        },
+        shine: {
+          '0%, 100%': { 'background-position': '0% 50%' },
+          '50%': { 'background-position': '100% 50%' },
+        },
       },
       backdropBlur: {
         xs: '2px',


### PR DESCRIPTION
This commit updates the styling for the "О нас", "Блог", and "Премиум" navigation links in the header based on user feedback.

- Replaces the previous pastel gradient with a more saturated and vibrant gradient (`from-pink-500` to `to-rose-500`) to improve text visibility and visual appeal.
- The gradient is applied to both the text and the hover underline effect for a consistent look.
- This change addresses the user's request for a more prominent and eye-catching design.