### PR TITLE
feat: make header gradient more saturated

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,16 +151,16 @@ export const Header: React.FC<HeaderProps> = () => {
         
         <nav className="flex items-center space-x-2 sm:space-x-4 xl:space-x-6">
           <a href="#about" className="relative group hidden lg:block px-3 py-2">
-            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary-dark to-accent group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-accent to-accent-vibrant group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.about')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary-dark to-accent rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-accent to-accent-vibrant rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <a href="#articles" className="relative group px-3 py-2">
-            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary-dark to-accent group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-accent to-accent-vibrant group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.articles')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary-dark to-accent rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-accent to-accent-vibrant rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -151,16 +151,16 @@ export const Header: React.FC<HeaderProps> = () => {
         
         <nav className="flex items-center space-x-2 sm:space-x-4 xl:space-x-6">
           <a href="#about" className="relative group hidden lg:block px-3 py-2">
-            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary-dark to-accent group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.about')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary-dark to-accent rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <a href="#articles" className="relative group px-3 py-2">
-            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+            <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary-dark to-accent group-hover:opacity-90 transition-opacity duration-300">
               {t('nav.articles')}
             </span>
-            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+            <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary-dark to-accent rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
           </a>
           <HeaderPremium />
           <button

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -10,10 +10,10 @@ function HeaderPremium() {
         onClick={() => setOpen(true)}
         className="relative group px-3 py-2"
       >
-        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary to-primary group-hover:opacity-90 transition-opacity duration-300">
+        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary-dark to-accent group-hover:opacity-90 transition-opacity duration-300">
           Премиум
         </span>
-        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary to-primary rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary-dark to-accent rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />
     </>

--- a/src/components/HeaderPremium.tsx
+++ b/src/components/HeaderPremium.tsx
@@ -10,10 +10,10 @@ function HeaderPremium() {
         onClick={() => setOpen(true)}
         className="relative group px-3 py-2"
       >
-        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-secondary-dark to-accent group-hover:opacity-90 transition-opacity duration-300">
+        <span className="text-sm sm:text-base font-semibold text-transparent bg-clip-text bg-gradient-to-r from-accent to-accent-vibrant group-hover:opacity-90 transition-opacity duration-300">
           Премиум
         </span>
-        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-secondary-dark to-accent rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
+        <span className="absolute bottom-1 left-0 w-full h-[2px] bg-gradient-to-r from-accent to-accent-vibrant rounded-full transform scale-x-0 group-hover:scale-x-100 transition-transform duration-500 ease-out origin-center"></span>
       </button>
       <PricingModal open={open} onClose={() => setOpen(false)} />
     </>


### PR DESCRIPTION
This commit updates the gradient color for the 'О нас', 'Блог', and 'Премиум' text in the header to be more saturated. The change is made by replacing the 'from-secondary to-primary' gradient with 'from-secondary-dark to-accent'.